### PR TITLE
Add missing dom-module import

### DIFF
--- a/theme/lumo/vcf-autosuggest-styles.js
+++ b/theme/lumo/vcf-autosuggest-styles.js
@@ -1,3 +1,4 @@
+import '@polymer/polymer/lib/elements/dom-module.js';
 import '@vaadin/vaadin-lumo-styles/style';
 
 const theme = document.createElement('dom-module');


### PR DESCRIPTION
Latest versions of vaadin-themable-mixin.js no longer imports the polymer's dom-module. However this add-in still uses polymer templates and the dom-module web-component is required.